### PR TITLE
use better directory detection in scripts

### DIFF
--- a/common/create-ldap-and-postgres-isvaop-keys.sh
+++ b/common/create-ldap-and-postgres-isvaop-keys.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
   
 # Get directory for this script
-RUNDIR="`dirname \"$0\"`"         # relative
-RUNDIR="`( cd \"$RUNDIR\" && pwd )`"  # absolutized and normalized
+RUNDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 if [ -z "$RUNDIR" ] ; then
   echo "Failed to get local path"
   exit 1  # fail

--- a/common/env-config.sh
+++ b/common/env-config.sh
@@ -25,14 +25,13 @@ LDAP_VERSION=latest
 DB_VERSION=11.0.0.0
 IVIAOP_VERSION=24.12
 
-set -o
 # Get directory for this script
 PARENT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && cd .. && pwd )"
 if [ -z "$PARENT" ] ; then
   echo "Failed to get local path"
   exit 1  # fail
 fi
-set +o
+
 # Location where Keystores will be created
 DOCKERKEYS=${PARENT}/local/dockerkeys
 IVIAOPCONFIG=${PARENT}/common/isvaop-config

--- a/common/env-config.sh
+++ b/common/env-config.sh
@@ -25,18 +25,17 @@ LDAP_VERSION=latest
 DB_VERSION=11.0.0.0
 IVIAOP_VERSION=24.12
 
-
+set -o
 # Get directory for this script
-THISDIR="`dirname \"$0\"`"         # relative
-THISDIR="`( cd \"$THISDIR/..\" && pwd )`"  # absolutized and normalized
-if [ -z "$THISDIR" ] ; then
+PARENT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && cd .. && pwd )"
+if [ -z "$PARENT" ] ; then
   echo "Failed to get local path"
   exit 1  # fail
 fi
-
+set +o
 # Location where Keystores will be created
-DOCKERKEYS=${THISDIR}/local/dockerkeys
-IVIAOPCONFIG=${THISDIR}/common/isvaop-config
+DOCKERKEYS=${PARENT}/local/dockerkeys
+IVIAOPCONFIG=${PARENT}/common/isvaop-config
 # Location where Docker Shares will be created
 # Note that this directory is also hardcoded into YAML files
 DOCKERSHARE=${HOME}/dockershare

--- a/common/restore-keys.sh
+++ b/common/restore-keys.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # Get directory for this script
-RUNDIR="`dirname \"$0\"`"         # relative
-RUNDIR="`( cd \"$RUNDIR\" && pwd )`"  # absolutized and normalized
+RUNDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 if [ -z "$RUNDIR" ] ; then
   echo "Failed to get local path"
   exit 1  # fail

--- a/docker/docker-setup.sh
+++ b/docker/docker-setup.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # Get directory for this script
-RUNDIR="`dirname \"$0\"`"         # relative
-RUNDIR="`( cd \"$RUNDIR\" && pwd )`"  # absolutized and normalized
+RUNDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 if [ -z "$RUNDIR" ] ; then
   echo "Failed to get local path"
   exit 1  # fail

--- a/docker/ivia-backup-docker.sh
+++ b/docker/ivia-backup-docker.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Get directory for this script
-RUNDIR="`dirname \"$0\"`"         # relative
-RUNDIR="`( cd \"$RUNDIR\" && pwd )`"  # absolutized and normalized
+RUNDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+#RUNDIR="`dirname \"$0\"`"         # relative
+#RUNDIR="`( cd \"$RUNDIR\" && pwd )`"  # absolutized and normalized
 if [ -z "$RUNDIR" ] ; then
   echo "Failed to get local path"
   exit 1  # fail

--- a/docker/ivia-backup-docker.sh
+++ b/docker/ivia-backup-docker.sh
@@ -2,8 +2,6 @@
 
 # Get directory for this script
 RUNDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-#RUNDIR="`dirname \"$0\"`"         # relative
-#RUNDIR="`( cd \"$RUNDIR\" && pwd )`"  # absolutized and normalized
 if [ -z "$RUNDIR" ] ; then
   echo "Failed to get local path"
   exit 1  # fail


### PR DESCRIPTION
without these changes the scripts will only work if you're in a particular directory, otherwise they get the directory name twice in the env var (with a newline) and fail.  BASH_SOURCE is a more reliable method of getting the dir (especially in the env-common script sourced into the other scripts).